### PR TITLE
change: no linenos by default

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -99,8 +99,7 @@ kramdown:
   input: GFM
   syntax_highlighter: rouge
   syntax_highlighter_opts:
-    block:
-      line_numbers: true
+    css_class: 'highlight'
 
 # Adsense (change to "enabled" to activate, also your client id and ad slot. Create a new ad unit from your Adsense account to get the slot.)
 adsense: "disabled"

--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -67,3 +67,8 @@
 
 td.rouge-code { width: 100%;}
 pre.lineno { color: #9999;}
+
+pre.highlight {
+    background-color: rgb(246, 248, 250);
+    padding: 1rem;
+}


### PR DESCRIPTION
Changes the config so that line numbers are disabled by default.

Why? Because for single-line code snippets that are supposed to be copy-pasted, the way rouge creates HTML is kind of ridiculous:

<img width="695" alt="Screen Shot 2020-09-03 at 8 05 18 PM" src="https://user-images.githubusercontent.com/2294397/92191526-3fcdba00-ee21-11ea-867b-e0f9965f88a2.png">

So I disabled that, and tweaked the CSS to match:

<img width="687" alt="Screen Shot 2020-09-03 at 8 04 30 PM" src="https://user-images.githubusercontent.com/2294397/92191554-4eb46c80-ee21-11ea-90c5-d7da5a990060.png">


See also:  https://github.com/jekyll/jekyll/issues/4619#issuecomment-191267346