### PR TITLE
fix(g2p): activate a hyperlink

### DIFF
--- a/_posts/2021-10-23-g2p-basic-mappings-local.md
+++ b/_posts/2021-10-23-g2p-basic-mappings-local.md
@@ -206,4 +206,4 @@ Then, type the following command in your command line or integrated terminal: `g
 
 ### Footnotes
 
-[^1]: See this link for more information on the difference between pip and pip3: https://www.pythonpool.com/pip-vs-pip3/
+[^1]: See this link for more information on the difference between pip and pip3: <https://www.pythonpool.com/pip-vs-pip3/>


### PR DESCRIPTION
trivial patch, activating one hyperlinked that got missed. I copied the `<http:...>` syntax from other functional hyperlinks on the blog. It's nice to be able to just add `<` and `>` around the hyperlink if you just want to display the link itself as its own hyperlink text.