### PR TITLE
fix broken hyperlink due to typo

### DIFF
--- a/_posts/2021-10-24-g2p-advanced-mappings.md
+++ b/_posts/2021-10-24-g2p-advanced-mappings.md
@@ -29,7 +29,7 @@ You may have noticed that the rules described in the previous posts for converti
 As this post is quite long, please refer to the following index for quick navigation:
 
 - [Rule Ordering](#rule-ordering)
-- [Unicode Escape Sequences](#unicode-escape-equences)
+- [Unicode Escape Sequences](#unicode-escape-sequences)
 - [Special Settings & Configuration](#special-settings-for-your-mapping-configuration)
 - [Defining variables](#defining-sets-of-characters)
 - [Regular Expresssions](#regular-expressions)


### PR DESCRIPTION
There's a broken link in https://blog.mothertongues.org/g2p-advanced-mappings/#unicode-escape-equences due to a typo, which I fixed in this tiny commit/PR.

Feel free to cherry pick the one commit instead of merging this PR in.