### PR TITLE
fix: make the first paragraph contentful

### DIFF
--- a/_posts/2020-07-31-post-template.md
+++ b/_posts/2020-07-31-post-template.md
@@ -68,3 +68,7 @@ It will produce the following image:
 The text after the `--alt` is the text that will show up if the image
 doesn't load, or the text that screenreader users will hear when
 listening to the blog post.
+
+## Text for the blog post card
+
+Please note that the first paragraph of the post (the one that starts with "This blog post" above) is what shows up on the card for the post so please make it brief but contentful. If you just start with `# TL;DR`, that's what will show up on the card instead of your short pitch, you don't really want that. Think of your first paragraph as the text that will encourage people to read your post.

--- a/_posts/2020-08-13-convertextract-app.md
+++ b/_posts/2020-08-13-convertextract-app.md
@@ -10,8 +10,6 @@ featured: false
 hidden: false
 ---
 
-# TL;DR
-
 Have you ever wanted to *NOT* spend hours tediously checking that **k + '** is written as **k̓** and not **k'**?
 If you said **YES!**, *Convertextract* is the app for you. With minimal technical knowledge, you can now systemically make your [ELAN](https://archive.mpi.nl/tla/elan) annotations consistent.
 

--- a/_posts/2022-01-25-wordle.md
+++ b/_posts/2022-01-25-wordle.md
@@ -10,8 +10,6 @@ featured: true
 hidden: false
 ---
 
-# TL;DR
-
 This tutorial will help you adapt the popular [Wordle game](https://www.powerlanguage.co.uk/wordle/) to another language!
 
 # What you need to know to understand this post

--- a/_posts/2023-03-09-common-voice.md
+++ b/_posts/2023-03-09-common-voice.md
@@ -10,8 +10,6 @@ featured: false
 hidden: false
 ---
 
-# TL;DR
-
 The National Research Council and Ursa Creative have adapted Mozilla’s CommonVoice tool to help streamline recording and data management for Indigenous language revitalization.
 
 # What you need to know to understand this post

--- a/_posts/2023-04-21-typesetting-syllabics-and-more-in-latex.md
+++ b/_posts/2023-04-21-typesetting-syllabics-and-more-in-latex.md
@@ -10,8 +10,6 @@ featured: false
 hidden: false
 ---
 
-# TL;DR
-
 This post describes one way to use certain Inuktut syllabics fonts when writing documents in LaTeX, along with some other LaTeX tips.
 
 # What you need to know to understand this post


### PR DESCRIPTION
The line `# TL;DR` got picked up the the short post summary by the system that automatically generates the cards for the post. The solution I propose is to keep the TL;DR at the top but not label it as such.